### PR TITLE
Enhance duration input and add optional calendar start date

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify, render_template
+from datetime import datetime, timedelta
 # from werkzeug.exceptions import BadRequest # No longer explicitly needed for get_json error handling
 # Ensure timecalculator package is discoverable.
 # If app.py is at the root, and timecalculator is a dir at the root,
@@ -61,6 +62,7 @@ def calculate_time_api():
     initial_time_str = data.get('initial_time')
     duration_str = data.get('duration')
     days_offset_str = data.get('days_offset', '0') # Default to '0' as a string
+    start_date_str = data.get('start_date') # Optional
 
     if not initial_time_str:
         return jsonify({"error": "Missing 'initial_time'"}), 400
@@ -68,47 +70,97 @@ def calculate_time_api():
         return jsonify({"error": "Missing 'duration'"}), 400
 
     try:
-        time_obj = Time(initial_time_str)
-        duration_obj = Duration(duration_str)
+        if not start_date_str:
+            # --- Existing logic without start_date ---
+            time_obj = Time(initial_time_str)
+            duration_obj = Duration(duration_str)
 
-        days_offset = 0 # Default
-        # days_offset_str comes from data.get('days_offset', '0')
-        # So it will be a string '0' by default, or actual value from JSON if provided.
+            days_offset = 0
+            if isinstance(days_offset_str, (int, str)):
+                try:
+                    days_offset = int(days_offset_str)
+                except ValueError:
+                    return jsonify({"error": "Invalid format for days_offset, must be a string representing an integer."}), 400
+            else:
+                return jsonify({"error": "Invalid type for days_offset, must be an integer or a string representing an integer."}), 400
 
-        if isinstance(days_offset_str, (int, str)):
+            new_time_obj, days_from_duration = time_obj + duration_obj
+            total_days_passed = days_from_duration + days_offset
+
+            calculated_time_str = str(new_time_obj)
+            result_display_str = calculated_time_str
+
+            if total_days_passed == 1:
+                result_display_str += " (next day)"
+            elif total_days_passed > 1:
+                result_display_str += f" ({total_days_passed} days later)"
+            elif total_days_passed == -1:
+                result_display_str += " (previous day)"
+            elif total_days_passed < -1:
+                result_display_str += f" ({abs(total_days_passed)} days prior)"
+
+            return jsonify({
+                "result_string": result_display_str,
+                "calculated_time": calculated_time_str,
+                "days_numeric": total_days_passed
+            }), 200
+        else:
+            # --- New logic with start_date ---
+            # Parse initial_time_str to get hours and minutes
+            time_obj_for_parsing = Time(initial_time_str) # Can raise ValueError
+            parsed_hours = time_obj_for_parsing.minutes_from_midnight // 60
+            parsed_minutes = time_obj_for_parsing.minutes_from_midnight % 60
+
+            # Parse start_date_str
             try:
-                days_offset = int(days_offset_str) # Handles int, or string like "1", "-2"
-            except ValueError: # Handles string like "abc"
-                return jsonify({"error": "Invalid format for days_offset, must be a string representing an integer."}), 400
-        else: # It's a float, boolean, list, dict etc. from JSON
-            return jsonify({"error": "Invalid type for days_offset, must be an integer or a string representing an integer."}), 400
+                start_datetime_obj = datetime.strptime(start_date_str, '%Y-%m-%d')
+            except ValueError: # Catches invalid date format for start_date_str
+                return jsonify({"error": f"Invalid start_date format. Expected YYYY-MM-DD, got '{start_date_str}'"}), 400
 
-        new_time_obj, days_from_duration = time_obj + duration_obj
-        total_days_passed = days_from_duration + days_offset
+            # Combine into a full start datetime
+            full_start_datetime = start_datetime_obj.replace(
+                hour=parsed_hours, minute=parsed_minutes, second=0, microsecond=0
+            )
 
-        calculated_time_str = str(new_time_obj)
-        result_display_str = calculated_time_str
+            # Process Duration
+            duration_obj = Duration(duration_str) # Can raise ValueError
+            duration_timedelta = timedelta(seconds=duration_obj.total_seconds)
 
-        # Update display string based on total_days_passed
-        if total_days_passed == 1:
-            result_display_str += " (next day)"
-        elif total_days_passed > 1:
-            result_display_str += f" ({total_days_passed} days later)"
-        elif total_days_passed == -1:
-            result_display_str += " (previous day)"
-        elif total_days_passed < -1:
-            result_display_str += f" ({abs(total_days_passed)} days prior)"
-        # No suffix if total_days_passed is 0
+            # Apply days_offset if provided and valid. This is an ADDITION to the duration itself.
+            # Note: The original logic applied days_offset on top of the duration's days.
+            # Here, we add it to the start_datetime before adding the main duration, or add it to the duration_timedelta.
+            # Let's add it to duration_timedelta for simplicity, consistent with how Duration might handle "X days".
+            # Or, more directly, add to full_start_datetime if it's purely a date shift.
+            # The original spec for days_offset was for the non-calendar case.
+            # For calendar case, if days_offset is to be supported, it should shift the full_start_datetime.
 
-        return jsonify({
-            "result_string": result_display_str,
-            "calculated_time": calculated_time_str,
-            "days_numeric": total_days_passed
-        }), 200
+            current_days_offset = 0
+            if isinstance(days_offset_str, (int, str)) and days_offset_str != '0': # Only process if not default '0'
+                try:
+                    current_days_offset = int(days_offset_str)
+                    full_start_datetime += timedelta(days=current_days_offset)
+                except ValueError:
+                     return jsonify({"error": "Invalid format for days_offset, must be a string representing an integer when used with start_date."}), 400
+            elif not isinstance(days_offset_str, (int, str)) and days_offset_str != '0':
+                 return jsonify({"error": "Invalid type for days_offset, must be an integer or a string representing an integer when used with start_date."}), 400
 
-    except ValueError as e: # Catches errors from Time/Duration init
-        return jsonify({"error": str(e)}), 400
-    # TypeError from int() if days_offset_str is e.g. a list is already caught by the new days_offset logic returning 400.
+
+            # Calculate End Datetime
+            end_datetime_obj = full_start_datetime + duration_timedelta
+
+            # Format Output Strings
+            start_dt_str_formatted = full_start_datetime.strftime('%Y-%m-%d %I:%M %p')
+            end_dt_str_formatted = end_datetime_obj.strftime('%Y-%m-%d %I:%M %p')
+            duration_details = str(duration_obj) # e.g., "X days, H:MM:SS"
+
+            return jsonify({
+                "start_datetime_str": start_dt_str_formatted,
+                "end_datetime_str": end_dt_str_formatted,
+                "duration_details_str": duration_details
+            }), 200
+
+    except ValueError as e: # Catches errors from Time/Duration init or other ValueErrors like strptime
+        return jsonify({"error": f"Error processing time/duration: {str(e)}"}), 400
     # A direct TypeError for days_offset itself is less likely with the new logic.
     # The previous custom TypeError for days_offset is removed in favor of direct int conversion attempt.
     except Exception as e:

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,14 +19,30 @@
                         <span class="field-error-message" id="initial_time_error"></span>
             </div>
             <div>
-                <label for="duration">Duration:</label>
-                <input type="text" id="duration" name="duration" placeholder="e.g., 3:10:30 or 1 day, 2:00">
-                        <span class="field-error-message" id="duration_error"></span>
+                <label for="duration_value">Duration Value:</label>
+                <input type="number" id="duration_value" name="duration_value" placeholder="e.g., 10" min="0">
+                <label for="duration_unit">Duration Unit:</label>
+                <select id="duration_unit" name="duration_unit">
+                    <option value="seconds">Seconds</option>
+                    <option value="minutes">Minutes</option>
+                    <option value="hours">Hours</option>
+                    <option value="days">Days</option>
+                </select>
+                <span class="field-error-message" id="duration_error"></span>
             </div>
             <div>
                 <label for="days_offset">Days Offset (optional):</label>
                 <input type="text" id="days_offset" name="days_offset" placeholder="e.g., 1, -1 (default 0)">
                         <span class="field-error-message" id="days_offset_error"></span>
+            </div>
+            <div>
+                <label for="use_start_date">Use Start Date?</label>
+                <input type="checkbox" id="use_start_date" name="use_start_date">
+            </div>
+            <div id="start_date_section" style="display: none;">
+                <label for="start_date">Start Date:</label>
+                <input type="date" id="start_date" name="start_date">
+                <span class="field-error-message" id="start_date_error"></span>
             </div>
                     <div class="button-group">
                         <button id="calculate_button">Calculate</button>

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -116,6 +116,132 @@ class TestAPI(unittest.TestCase):
         data = json.loads(response.data)
         self.assertEqual(data.get('error'), "Invalid JSON payload or Content-Type (must be application/json and valid JSON)")
 
+    # --- Tests for New Duration Inputs and Start Date Functionality ---
+
+    def _construct_duration_str(self, value, unit):
+        if unit == "seconds":
+            return f"0:00:{int(value):02d}"
+        elif unit == "minutes":
+            return f"0:{int(value):02d}:00"
+        elif unit == "hours":
+            return f"{int(value)}:00:00"
+        elif unit == "days":
+            return f"{int(value)} days, 0:00:00"
+        raise ValueError(f"Unknown duration unit: {unit}")
+
+    def test_calculate_with_new_duration_units_no_start_date(self):
+        test_cases = [
+            {"value": 30, "unit": "seconds", "initial_time": "1:00:00 PM", "expected_time": "1:00 PM", "expected_result": "1:00 PM", "expected_days": 0}, # Duration is 30s, Time class is minute precision.
+            {"value": 30, "unit": "seconds", "initial_time": "1:00 PM", "duration_str_override": "0:00:30", "expected_time": "1:00 PM", "expected_result": "1:00 PM", "expected_days": 0}, # Explicit duration string for clarity
+            {"value": 2, "unit": "hours", "initial_time": "1:00 PM", "expected_time": "3:00 PM", "expected_result": "3:00 PM", "expected_days": 0},
+            {"value": 3, "unit": "days", "initial_time": "1:00 PM", "expected_time": "1:00 PM", "expected_result": "1:00 PM (3 days later)", "expected_days": 3},
+            {"value": 90, "unit": "minutes", "initial_time": "2:00 PM", "duration_str_override": "0:90:00", "expected_time": "3:30 PM", "expected_result": "3:30 PM", "expected_days": 0}, # Test with minutes > 59
+        ]
+
+        for tc in test_cases:
+            duration_str = tc.get("duration_str_override") or self._construct_duration_str(tc["value"], tc["unit"])
+            payload = {"initial_time": tc["initial_time"], "duration": duration_str}
+            with self.subTest(payload=payload):
+                response = self.client.post('/api/calculate_time', json=payload)
+                self.assertEqual(response.status_code, 200, msg=f"Failed for {payload}, response: {response.data.decode()}")
+                data = json.loads(response.data)
+                self.assertEqual(data.get('calculated_time'), tc["expected_time"])
+                self.assertEqual(data.get('result_string'), tc["expected_result"])
+                self.assertEqual(data.get('days_numeric'), tc["expected_days"])
+
+    def test_calculate_with_start_date(self):
+        payload = {
+            "initial_time": "10:00 AM",
+            "duration": self._construct_duration_str(5, "hours"), # "5:00:00"
+            "start_date": "2023-10-26"
+        }
+        response = self.client.post('/api/calculate_time', json=payload)
+        self.assertEqual(response.status_code, 200, msg=response.data.decode())
+        data = json.loads(response.data)
+        self.assertEqual(data.get('start_datetime_str'), "2023-10-26 10:00 AM")
+        self.assertEqual(data.get('end_datetime_str'), "2023-10-26 03:00 PM")
+        self.assertEqual(data.get('duration_details_str'), "5:00:00") # Duration class __str__
+
+    def test_calculate_with_start_date_and_days_offset(self):
+        payload = {
+            "initial_time": "10:00 AM",
+            "duration": self._construct_duration_str(2, "hours"), # "2:00:00"
+            "start_date": "2023-10-26",
+            "days_offset": "1"
+        }
+        response = self.client.post('/api/calculate_time', json=payload)
+        self.assertEqual(response.status_code, 200, msg=response.data.decode())
+        data = json.loads(response.data)
+        # days_offset (1) is applied to start_date (2023-10-26), so effective start is 2023-10-27
+        self.assertEqual(data.get('start_datetime_str'), "2023-10-27 10:00 AM")
+        self.assertEqual(data.get('end_datetime_str'), "2023-10-27 12:00 PM")
+        self.assertEqual(data.get('duration_details_str'), "2:00:00")
+
+    def test_calculate_with_start_date_and_negative_days_offset(self):
+        payload = {
+            "initial_time": "01:00 AM", # 1:00
+            "duration": self._construct_duration_str(2, "hours"), # "2:00:00"
+            "start_date": "2023-10-26",
+            "days_offset": "-2"
+        }
+        response = self.client.post('/api/calculate_time', json=payload)
+        self.assertEqual(response.status_code, 200, msg=response.data.decode())
+        data = json.loads(response.data)
+        self.assertEqual(data.get('start_datetime_str'), "2023-10-24 01:00 AM")
+        self.assertEqual(data.get('end_datetime_str'), "2023-10-24 03:00 AM")
+        self.assertEqual(data.get('duration_details_str'), "2:00:00")
+
+
+    def test_calculate_with_start_date_crossing_boundaries(self):
+        test_cases = [
+            {
+                "name": "Month Boundary",
+                "payload": {
+                    "initial_time": "10:00 PM", "duration": self._construct_duration_str(5, "hours"), # "5:00:00"
+                    "start_date": "2023-10-31"
+                },
+                "expected_start": "2023-10-31 10:00 PM", "expected_end": "2023-11-01 03:00 AM"
+            },
+            {
+                "name": "Year Boundary",
+                "payload": {
+                    "initial_time": "10:00 PM", "duration": self._construct_duration_str(5, "hours"), # "5:00:00"
+                    "start_date": "2023-12-31"
+                },
+                "expected_start": "2023-12-31 10:00 PM", "expected_end": "2024-01-01 03:00 AM"
+            }
+        ]
+        for tc in test_cases:
+            with self.subTest(name=tc["name"], payload=tc["payload"]):
+                response = self.client.post('/api/calculate_time', json=tc["payload"])
+                self.assertEqual(response.status_code, 200, msg=response.data.decode())
+                data = json.loads(response.data)
+                self.assertEqual(data.get('start_datetime_str'), tc["expected_start"])
+                self.assertEqual(data.get('end_datetime_str'), tc["expected_end"])
+
+    def test_error_invalid_start_date_format(self):
+        payload = {
+            "initial_time": "10:00 AM",
+            "duration": self._construct_duration_str(1, "hours"),
+            "start_date": "invalid-date-format"
+        }
+        response = self.client.post('/api/calculate_time', json=payload)
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertIn("Invalid start_date format. Expected YYYY-MM-DD", data.get('error', ''))
+
+    def test_error_invalid_days_offset_with_start_date(self):
+        payload = {
+            "initial_time": "10:00 AM",
+            "duration": self._construct_duration_str(1, "hours"),
+            "start_date": "2023-10-26",
+            "days_offset": "not-an-integer"
+        }
+        response = self.client.post('/api/calculate_time', json=payload)
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertIn("Invalid format for days_offset, must be a string representing an integer when used with start_date.", data.get('error', ''))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit implements the following changes:

1.  **Duration Input Fields:**
    *   The single duration text input in `index.html` has been replaced by two fields:
        *   A numerical input for the duration value.
        *   A dropdown to select the duration unit (seconds, minutes, hours, days).
    *   `static/script.js` has been updated to construct the duration string for the backend based on these new inputs.

2.  **Optional Calendar Start Date:**
    *   An optional "Start Date" section has been added to `index.html`.
        *   A checkbox allows you to enable this feature.
        *   A date input field allows you to select a start date.
    *   `static/script.js` handles the UI logic for this section and sends the start date to the backend if provided.
    *   `app.py` has been updated:
        *   If a start date is provided, the API now calculates the end date and time, returning a JSON response with start datetime, end datetime, and duration details. Python's `datetime` and `timedelta` are used for these calculations.
        *   The `days_offset` is also correctly applied to the start date if both are provided.
        *   If no start date is provided, the API behaves as before.

3.  **Client-Side Updates:**
    *   Input validation in `static/script.js` has been updated for the new fields.
    *   Preset management (save/load) now includes the new duration fields and start date information.
    *   Local storage now saves the state of the new input fields.
    *   The result display area is updated to show either the old format or the new date/time comparison based on the API response.

4.  **Unit Tests:**
    *   New unit tests have been added to `tests/test_webapp.py` to cover:
        *   Calculations with the new duration input types.
        *   Calculations involving a start date, including cases with day offsets and boundary crossings (month/year).
        *   Error handling for invalid start date formats.

These changes provide you with a more intuitive way to input durations and an advanced option to calculate end dates based on a specific start date.